### PR TITLE
Add totals to scoreboards and autocompletion for Endbot backup command

### DIFF
--- a/src/main/java/io/github/samipourquoi/endtech/endbot/BackupEndbotCommand.java
+++ b/src/main/java/io/github/samipourquoi/endtech/endbot/BackupEndbotCommand.java
@@ -1,15 +1,13 @@
 package io.github.samipourquoi.endtech.endbot;
 
 import com.mojang.brigadier.CommandDispatcher;
-import net.minecraft.command.argument.EntityArgumentType;
 
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
-import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
 
-public class PosEndBotCommand {
+public class BackupEndbotCommand {
     public static void register(CommandDispatcher<Object> dispatcher) {
         dispatcher.register(
-                literal("pos")
-                        .then(argument("player", EntityArgumentType.players())));
+                literal("backup")
+        );
     }
 }

--- a/src/main/java/io/github/samipourquoi/endtech/endbot/EndbotCommandDispatcher.java
+++ b/src/main/java/io/github/samipourquoi/endtech/endbot/EndbotCommandDispatcher.java
@@ -13,5 +13,6 @@ public class EndbotCommandDispatcher {
         HelpEndbotCommand.register(INSTANCE);
         PresetsEndbotCommand.register(INSTANCE);
         PosEndBotCommand.register(INSTANCE);
+        BackupEndbotCommand.register(INSTANCE);
     }
 }

--- a/src/main/java/io/github/samipourquoi/endtech/endbot/PresetsEndbotCommand.java
+++ b/src/main/java/io/github/samipourquoi/endtech/endbot/PresetsEndbotCommand.java
@@ -3,8 +3,6 @@ package io.github.samipourquoi.endtech.endbot;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
-import net.minecraft.command.argument.EntityArgumentType;
-import net.minecraft.command.argument.ObjectiveArgumentType;
 import net.minecraft.command.argument.TextArgumentType;
 
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;

--- a/src/main/java/io/github/samipourquoi/endtech/endbot/ScoreboardEndbotCommand.java
+++ b/src/main/java/io/github/samipourquoi/endtech/endbot/ScoreboardEndbotCommand.java
@@ -1,13 +1,9 @@
 package io.github.samipourquoi.endtech.endbot;
 
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.context.StringRange;
-import com.mojang.brigadier.suggestion.Suggestions;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.command.argument.EntityArgumentType;
-
-import java.util.concurrent.CompletableFuture;
 
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;

--- a/src/main/java/io/github/samipourquoi/endtech/helpers/RuleSettings.java
+++ b/src/main/java/io/github/samipourquoi/endtech/helpers/RuleSettings.java
@@ -1,0 +1,86 @@
+package io.github.samipourquoi.endtech.helpers;
+
+import net.minecraft.network.packet.s2c.play.ScoreboardPlayerUpdateS2CPacket;
+import net.minecraft.scoreboard.ScoreboardObjective;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.WorldSavePath;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+public class RuleSettings {
+    public static boolean scoreboardTotals;
+    private static MinecraftServer server;
+
+    public static int setScoreboardTotal(ServerCommandSource source, boolean boolean1) {
+        MinecraftServer server = source.getMinecraftServer();
+        scoreboardTotals = boolean1;
+
+        source.sendFeedback(new TranslatableText("Set scoreboardTotals to " + scoreboardTotals),true);
+        if (!boolean1)
+            removeTotalScore(server);
+        else
+            addTotalScore(server);
+
+        writeConfigSettings(server, boolean1);
+        return 1;
+    }
+
+    private static void removeTotalScore(MinecraftServer server) {
+        server.getPlayerManager().sendToAll(
+                new ScoreboardPlayerUpdateS2CPacket(ServerScoreboard.UpdateMode.REMOVE, null, "Total", 0));
+    }
+
+    private static void addTotalScore(MinecraftServer server) {
+        ServerScoreboard scoreboard = server.getScoreboard();
+        ScoreboardObjective scoreboardObjective = scoreboard.getObjectiveForSlot(1);
+        if (scoreboardObjective == null) return;
+
+        scoreboard.createChangePackets(scoreboardObjective);
+    }
+
+    // Most code below this is from
+    // https://github.com/gnembon/fabric-carpet/blob/92063fa8917d4591234efe73bb9201942f814f11/src/main/java/carpet/settings/SettingsManager.java
+
+    public static void loadConfigSettings(MinecraftServer server) {
+        try (BufferedReader reader = Files.newBufferedReader(getFile(server))) {
+            String line = "";
+            while ((line = reader.readLine()) != null) {
+                String value = line.split(" ")[1];
+                boolean boolean2 = Boolean.parseBoolean(value);
+                scoreboardTotals = boolean2;
+            }
+        } catch (NoSuchFileException e) {
+            try {
+                if (Files.notExists(getFile(server))) {
+                    Files.createFile(getFile(server));
+                }
+            } catch (IOException e2) {
+                System.out.println("Couldn't create config file for et-additions");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void writeConfigSettings(MinecraftServer server, boolean boolean1) {
+        try (BufferedWriter writer = Files.newBufferedWriter(getFile(server))) {
+            writer.write("scoreboardTotals " + boolean1);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Path getFile(MinecraftServer server) {
+        return server.getSavePath(WorldSavePath.ROOT).resolve("et-additions.txt");
+    }
+}
+
+

--- a/src/main/java/io/github/samipourquoi/endtech/helpers/RulesCommand.java
+++ b/src/main/java/io/github/samipourquoi/endtech/helpers/RulesCommand.java
@@ -1,0 +1,27 @@
+package io.github.samipourquoi.endtech.helpers;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.TranslatableText;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class RulesCommand {
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(
+                literal("et-additions").requires((serverCommandSource -> serverCommandSource.hasPermissionLevel(2))).
+                then(literal("scoreboardTotals").
+                        executes((commandContext) -> sendScoreboardTotalValue(commandContext.getSource())).
+                        then(literal("true").
+                            executes((commandContext) -> RuleSettings.setScoreboardTotal(commandContext.getSource(), true))).
+                        then(literal("false").
+                                executes((commandContext) -> RuleSettings.setScoreboardTotal(commandContext.getSource(), false)))));
+    }
+
+    public static int sendScoreboardTotalValue(ServerCommandSource source) {
+        source.sendFeedback(new TranslatableText("scoreboardTotal is currently set to " + RuleSettings.scoreboardTotals),true);
+        return 1;
+    }
+
+}
+

--- a/src/main/java/io/github/samipourquoi/endtech/helpers/RulesCommand.java
+++ b/src/main/java/io/github/samipourquoi/endtech/helpers/RulesCommand.java
@@ -1,8 +1,15 @@
 package io.github.samipourquoi.endtech.helpers;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardCriterion;
+import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
 
 import static net.minecraft.server.command.CommandManager.literal;
 
@@ -15,7 +22,12 @@ public class RulesCommand {
                         then(literal("true").
                             executes((commandContext) -> RuleSettings.setScoreboardTotal(commandContext.getSource(), true))).
                         then(literal("false").
-                                executes((commandContext) -> RuleSettings.setScoreboardTotal(commandContext.getSource(), false)))));
+                                executes((commandContext) -> RuleSettings.setScoreboardTotal(commandContext.getSource(), false)))).
+                        then(literal("customScoreboards").
+                                then(literal("generate").
+                                    executes((commandContext) -> generateCustomScoreboards(commandContext.getSource()))).
+                                then(literal("remove").
+                                        executes((commandContext) -> removeCustomScoreboards(commandContext.getSource())))));
     }
 
     public static int sendScoreboardTotalValue(ServerCommandSource source) {
@@ -23,5 +35,41 @@ public class RulesCommand {
         return 1;
     }
 
+    public static int generateCustomScoreboards(ServerCommandSource source) {
+        Scoreboard scoreboard = source.getMinecraftServer().getScoreboard();
+
+        for (Map.Entry<String, Identifier> value : StatsAccessor.CUSTOM_TAGS.entrySet()) {
+            String objectiveName = value.getKey();
+            //Currently doesn't automatically generate scoreboards with tags > 16 characters
+            if (objectiveName.length() > 16) continue;
+
+            ScoreboardObjective scoreboardObjective = scoreboard.getObjective(objectiveName);
+            if (scoreboardObjective != null) continue;
+
+            String criterionName = "minecraft.custom:minecraft." + value.getKey();
+            ScoreboardCriterion criterion = ScoreboardCriterion.createStatCriterion(criterionName).orElse(null);
+            if (criterion == null) continue;
+
+            scoreboard.addObjective(objectiveName, criterion, new LiteralText(objectiveName), criterion.getCriterionType());
+        }
+
+        source.sendFeedback(new TranslatableText("Created custom scoreboards from et-additions"), true);
+        return 1;
+    }
+
+    public static int removeCustomScoreboards(ServerCommandSource source) {
+        Scoreboard scoreboard = source.getMinecraftServer().getScoreboard();
+
+        for (Map.Entry<String, Identifier> value : StatsAccessor.CUSTOM_TAGS.entrySet()) {
+            String objectiveName = value.getKey();
+            ScoreboardObjective scoreboardObjective = scoreboard.getObjective(objectiveName);
+            if (scoreboardObjective == null) continue;
+
+            scoreboard.removeObjective(scoreboardObjective);
+        }
+
+        source.sendFeedback(new TranslatableText("Removed all scoreboards from et-additions"), true);
+        return 1;
+    }
 }
 

--- a/src/main/java/io/github/samipourquoi/endtech/mixin/MixinCommandManager.java
+++ b/src/main/java/io/github/samipourquoi/endtech/mixin/MixinCommandManager.java
@@ -1,0 +1,22 @@
+package io.github.samipourquoi.endtech.mixin;
+
+import com.mojang.brigadier.CommandDispatcher;
+import io.github.samipourquoi.endtech.helpers.RulesCommand;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CommandManager.class)
+public class MixinCommandManager {
+    @Shadow @Final private CommandDispatcher<ServerCommandSource> dispatcher;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onRegister(CallbackInfo ci) {
+        RulesCommand.register(this.dispatcher);
+    }
+}

--- a/src/main/java/io/github/samipourquoi/endtech/mixin/MixinMinecraftServer.java
+++ b/src/main/java/io/github/samipourquoi/endtech/mixin/MixinMinecraftServer.java
@@ -1,0 +1,16 @@
+package io.github.samipourquoi.endtech.mixin;
+
+import io.github.samipourquoi.endtech.helpers.RuleSettings;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "loadWorld", at = @At("HEAD"))
+    private void loadConf(CallbackInfo ci) {
+        RuleSettings.loadConfigSettings((MinecraftServer) (Object) this);
+    }
+}

--- a/src/main/java/io/github/samipourquoi/endtech/mixin/MixinScoreboardTotal.java
+++ b/src/main/java/io/github/samipourquoi/endtech/mixin/MixinScoreboardTotal.java
@@ -1,0 +1,49 @@
+package io.github.samipourquoi.endtech.mixin;
+
+import io.github.samipourquoi.endtech.helpers.RuleSettings;
+import net.minecraft.network.Packet;
+import net.minecraft.network.packet.s2c.play.ScoreboardPlayerUpdateS2CPacket;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardObjective;
+import net.minecraft.scoreboard.ScoreboardPlayerScore;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Mixin(ServerScoreboard.class)
+public class MixinScoreboardTotal extends Scoreboard {
+    @Final private MinecraftServer server;
+
+    @Inject(method = "updateScore", at = @At("TAIL"))
+    public void updateScoreboardTotal(ScoreboardPlayerScore score, CallbackInfo ci) {
+        if (RuleSettings.scoreboardTotals)
+            this.server.getPlayerManager().sendToAll(this.scoreboardTotalPacket(score.getObjective()));
+    }
+
+    @Inject(method = "createChangePackets", at = @At("TAIL"))
+    public void initializeTotals(ScoreboardObjective objective, CallbackInfoReturnable<List<Packet<?>>> cir) {
+        if (RuleSettings.scoreboardTotals) {
+            cir.getReturnValue().add(this.scoreboardTotalPacket(objective));
+            this.server.getPlayerManager().sendToAll(this.scoreboardTotalPacket(objective));
+        }
+    }
+
+    public ScoreboardPlayerUpdateS2CPacket scoreboardTotalPacket(ScoreboardObjective objective) {
+        int totalScore = 0;
+        Iterator<ScoreboardPlayerScore> scores = this.getAllPlayerScores(objective).iterator();;
+
+        while(scores.hasNext()) {
+            totalScore += scores.next().getScore();
+        }
+
+        return new ScoreboardPlayerUpdateS2CPacket(ServerScoreboard.UpdateMode.CHANGE, objective.getName(), "Total", totalScore);
+    }
+}

--- a/src/main/java/io/github/samipourquoi/endtech/mixin/MixinServerStatHandler.java
+++ b/src/main/java/io/github/samipourquoi/endtech/mixin/MixinServerStatHandler.java
@@ -1,0 +1,51 @@
+package io.github.samipourquoi.endtech.mixin;
+
+import io.github.samipourquoi.endtech.helpers.StatsAccessor;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.network.packet.s2c.play.StatisticsS2CPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.ServerStatHandler;
+import net.minecraft.stat.Stat;
+import net.minecraft.stat.StatHandler;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Iterator;
+import java.util.Set;
+
+@Mixin(ServerStatHandler.class)
+public abstract class MixinServerStatHandler extends StatHandler {
+    @Shadow @Final private MinecraftServer server;
+
+    @Shadow private int lastStatsUpdate;
+
+    @Shadow protected abstract Set<Stat<?>> takePendingStats();
+
+    @Overwrite
+    public void sendStats(ServerPlayerEntity player) {
+        int i = this.server.getTicks();
+        Object2IntMap<Stat<?>> object2IntMap = new Object2IntOpenHashMap();
+        if (i - this.lastStatsUpdate > 300) {
+            this.lastStatsUpdate = i;
+            Iterator var4 = this.takePendingStats().iterator();
+
+            while(var4.hasNext()) {
+                Stat<?> stat = (Stat)var4.next();
+
+                if (StatsAccessor.CUSTOM_TAGS.containsValue(stat.getValue())) continue;
+                if (StatsAccessor.DIG.equals(stat.getValue())) continue;
+                if (StatsAccessor.PICKS.equals(stat.getValue())) continue;
+                if (StatsAccessor.AXES.equals(stat.getValue())) continue;
+                if (StatsAccessor.SHOVELS.equals(stat.getValue())) continue;
+                if (StatsAccessor.HOES.equals(stat.getValue())) continue;
+                object2IntMap.put(stat, this.getStat(stat));
+            }
+        }
+
+        player.networkHandler.sendPacket(new StatisticsS2CPacket(object2IntMap));
+    }
+}

--- a/src/main/resources/endtech.mixins.json
+++ b/src/main/resources/endtech.mixins.json
@@ -9,7 +9,8 @@
     "MixinItemStack",
     "MixinScoreboardTotal",
     "MixinCommandManager",
-    "MixinMinecraftServer"
+    "MixinMinecraftServer",
+    "MixinServerStatHandler"
   ],
   "client": [
     "MixinMerchantScreen",

--- a/src/main/resources/endtech.mixins.json
+++ b/src/main/resources/endtech.mixins.json
@@ -6,7 +6,10 @@
   "mixins": [
     "MixinBlock",
     "MixinStats",
-    "MixinItemStack"
+    "MixinItemStack",
+    "MixinScoreboardTotal",
+    "MixinCommandManager",
+    "MixinMinecraftServer"
   ],
   "client": [
     "MixinMerchantScreen",


### PR DESCRIPTION
Autocompletes the backup command for endbot
Adds totals to scoreboards with an option to enable/disable it using the command: /et-additions scoreboardTotals. It also creates a text file to automatically load the scoreboardTotals on server restart